### PR TITLE
feat: return multiple errors on validation call

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,16 @@ func main() {
     "lastName" : "Michael"
     }`)
 
-	if err := rs.ValidateBytes(valid); err != nil {
+	if errors := rs.ValidateBytes(valid); len(errors) > 0 {
 		panic(err)
 	}
 
 	var invalidPerson = []byte(`{
     "firstName" : "Prince"
     }`)
-	err := rs.ValidateBytes(invalidPerson)
-	fmt.Println(err.Error())
+	if errors := rs.ValidateBytes(invalidPerson); len(errors) > 0 {
+  	fmt.Println(errs[0].Error())
+  }
 
 	var invalidFriend = []byte(`{
     "firstName" : "Jay",
@@ -92,8 +93,9 @@ func main() {
       "firstName" : "Nas"
       }]
     }`)
-	err = rs.ValidateBytes(invalidFriend)
-	fmt.Println(err)
+	if errors := rs.ValidateBytes(invalidFriend); len(errors) > 0 {
+  	fmt.Println(errors[0].Error())
+  }
 }
 ```
 
@@ -124,10 +126,12 @@ func newIsFoo() jsonschema.Validator {
 }
 
 // Validate implements jsonschema.Validator
-func (f IsFoo) Validate(data interface{}) error {
+func (f IsFoo) Validate(data interface{}) []jsonschema.ValError {
   if str, ok := data.(string); ok {
     if str != "foo" {
-      return fmt.Errorf("'%s' is not foo. It should be foo. plz make '%s' == foo. plz", str, str)
+      return []jsonschema.ValError{
+        {Message: fmt.Sprintf("'%s' is not foo. It should be foo. plz make '%s' == foo. plz", str, str)},
+      }
     }
   }
   return nil
@@ -148,10 +152,10 @@ func main() {
   }
 
   // validate some JSON
-  err := rs.ValidateBytes([]byte(`"bar"`))
+  errors := rs.ValidateBytes([]byte(`"bar"`))
 
   // print le error
-  fmt.Println(err.Error())
+  fmt.Println(errs[0].Error())
 
   // Output: 'bar' is not foo. It should be foo. plz make 'bar' == foo. plz
 }

--- a/keywords_conditionals.go
+++ b/keywords_conditionals.go
@@ -19,7 +19,7 @@ func newIif() Validator {
 }
 
 // Validate implements the Validator interface for iif
-func (i *iif) Validate(data interface{}) error {
+func (i *iif) Validate(data interface{}) []ValError {
 	if err := i.Schema.Validate(data); err == nil {
 		if i.then != nil {
 			s := Schema(*i.then)
@@ -71,7 +71,7 @@ func newThen() Validator {
 }
 
 // Validate implements the Validator interface for then
-func (t *then) Validate(data interface{}) error {
+func (t *then) Validate(data interface{}) []ValError {
 	return nil
 }
 
@@ -110,7 +110,7 @@ func newEls() Validator {
 }
 
 // Validate implements the Validator interface for els
-func (e *els) Validate(data interface{}) error {
+func (e *els) Validate(data interface{}) []ValError {
 	return nil
 }
 

--- a/keywords_numeric.go
+++ b/keywords_numeric.go
@@ -14,11 +14,13 @@ func newMultipleOf() Validator {
 }
 
 // Validate implements the Validator interface for multipleOf
-func (m multipleOf) Validate(data interface{}) error {
+func (m multipleOf) Validate(data interface{}) []ValError {
 	if num, ok := data.(float64); ok {
 		div := num / float64(m)
 		if float64(int(div)) != div {
-			return fmt.Errorf("%f must be a multiple of %f", num, m)
+			return []ValError{
+				{Message: fmt.Sprintf("%f must be a multiple of %f", num, m)},
+			}
 		}
 	}
 	return nil
@@ -34,10 +36,12 @@ func newMaximum() Validator {
 }
 
 // Validate implements the Validator interface for maximum
-func (m maximum) Validate(data interface{}) error {
+func (m maximum) Validate(data interface{}) []ValError {
 	if num, ok := data.(float64); ok {
 		if num > float64(m) {
-			return fmt.Errorf("%f must be less than or equal to %f", num, m)
+			return []ValError{
+				{Message: fmt.Sprintf("%f must be less than or equal to %f", num, m)},
+			}
 		}
 	}
 	return nil
@@ -53,10 +57,12 @@ func newExclusiveMaximum() Validator {
 }
 
 // Validate implements the Validator interface for exclusiveMaximum
-func (m exclusiveMaximum) Validate(data interface{}) error {
+func (m exclusiveMaximum) Validate(data interface{}) []ValError {
 	if num, ok := data.(float64); ok {
 		if num >= float64(m) {
-			return fmt.Errorf("%f must be less than %f", num, m)
+			return []ValError{
+				{Message: fmt.Sprintf("%f must be less than %f", num, m)},
+			}
 		}
 	}
 	return nil
@@ -71,10 +77,12 @@ func newMinimum() Validator {
 }
 
 // Validate implements the Validator interface for minimum
-func (m minimum) Validate(data interface{}) error {
+func (m minimum) Validate(data interface{}) []ValError {
 	if num, ok := data.(float64); ok {
 		if num < float64(m) {
-			return fmt.Errorf("%f must be greater than or equal to %f", num, m)
+			return []ValError{
+				{Message: fmt.Sprintf("%f must be greater than or equal to %f", num, m)},
+			}
 		}
 	}
 	return nil
@@ -89,10 +97,12 @@ func newExclusiveMinimum() Validator {
 }
 
 // Validate implements the Validator interface for exclusiveMinimum
-func (m exclusiveMinimum) Validate(data interface{}) error {
+func (m exclusiveMinimum) Validate(data interface{}) []ValError {
 	if num, ok := data.(float64); ok {
 		if num <= float64(m) {
-			return fmt.Errorf("%f must be greater than %f", num, m)
+			return []ValError{
+				{Message: fmt.Sprintf("%f must be greater than %f", num, m)},
+			}
 		}
 	}
 	return nil

--- a/keywords_strings.go
+++ b/keywords_strings.go
@@ -17,10 +17,12 @@ func newMaxLength() Validator {
 }
 
 // Validate implements the Validator interface for maxLength
-func (m maxLength) Validate(data interface{}) error {
+func (m maxLength) Validate(data interface{}) []ValError {
 	if str, ok := data.(string); ok {
 		if utf8.RuneCountInString(str) > int(m) {
-			return fmt.Errorf("max length of %d characters exceeded: %s", m, str)
+			return []ValError{
+				{Message: fmt.Sprintf("max length of %d characters exceeded: %s", m, str)},
+			}
 		}
 	}
 	return nil
@@ -37,10 +39,12 @@ func newMinLength() Validator {
 }
 
 // Validate implements the Validator interface for minLength
-func (m minLength) Validate(data interface{}) error {
+func (m minLength) Validate(data interface{}) []ValError {
 	if str, ok := data.(string); ok {
 		if utf8.RuneCountInString(str) < int(m) {
-			return fmt.Errorf("min length of %d characters required: %s", m, str)
+			return []ValError{
+				{Message: fmt.Sprintf("min length of %d characters required: %s", m, str)},
+			}
 		}
 	}
 	return nil
@@ -57,11 +61,13 @@ func newPattern() Validator {
 }
 
 // Validate implements the Validator interface for pattern
-func (p pattern) Validate(data interface{}) error {
+func (p pattern) Validate(data interface{}) []ValError {
 	re := regexp.Regexp(p)
 	if str, ok := data.(string); ok {
 		if !re.Match([]byte(str)) {
-			return fmt.Errorf("regext pattrn %s mismatch on string: %s", re.String(), str)
+			return []ValError{
+				{Message: fmt.Sprintf("regext pattrn %s mismatch on string: %s", re.String(), str)},
+			}
 		}
 	}
 	return nil

--- a/schema.go
+++ b/schema.go
@@ -15,6 +15,16 @@ import (
 	"net/url"
 )
 
+// Must turns a JSON string into a *RootSchema, panicing if parsing fails.
+// Useful for declaring Schemas in Go code.
+func Must(jsonString string) *RootSchema {
+	rs := &RootSchema{}
+	if err := rs.UnmarshalJSON([]byte(jsonString)); err != nil {
+		panic(err)
+	}
+	return rs
+}
+
 // DefaultSchemaPool is a package level map of schemas by identifier
 // remote references are cached here.
 var DefaultSchemaPool = Definitions{}

--- a/schema.go
+++ b/schema.go
@@ -157,10 +157,12 @@ func (rs *RootSchema) FetchRemoteReferences() error {
 
 // ValidateBytes performs schema validation against a slice of json
 // byte data
-func (rs *RootSchema) ValidateBytes(data []byte) error {
+func (rs *RootSchema) ValidateBytes(data []byte) []ValError {
 	var doc interface{}
 	if err := json.Unmarshal(data, &doc); err != nil {
-		return err
+		return []ValError{
+			{Message: fmt.Sprintf("error parsing JSON: %s", err.Error())},
+		}
 	}
 	return rs.Validate(doc)
 }
@@ -333,11 +335,16 @@ type Schema struct {
 
 // Validate uses the schema to check an instance, returning error on
 // the first error
-func (s *Schema) Validate(data interface{}) error {
+func (s *Schema) Validate(data interface{}) (errs []ValError) {
 	if s.Ref != "" && s.ref != nil {
-		return s.ref.Validate(data)
+		if ves := s.ref.Validate(data); len(ves) > 0 {
+			errs = append(errs, ves...)
+		}
+		return
 	} else if s.Ref != "" && s.ref == nil {
-		return fmt.Errorf("%s reference is nil for data: %v", s.Ref, data)
+		return []ValError{
+			{Message: fmt.Sprintf("%s reference is nil for data: %v", s.Ref, data)},
+		}
 	}
 
 	// TODO - so far all default.json tests pass when no use of
@@ -345,11 +352,11 @@ func (s *Schema) Validate(data interface{}) error {
 	// Is this correct?
 
 	for _, v := range s.Validators {
-		if err := v.Validate(data); err != nil {
-			return err
+		if ves := v.Validate(data); len(ves) > 0 {
+			errs = append(errs, ves...)
 		}
 	}
-	return nil
+	return
 }
 
 // JSONProp implements the JSONPather for Schema

--- a/schema_test.go
+++ b/schema_test.go
@@ -52,8 +52,8 @@ func ExampleBasic() {
 	var invalidPerson = []byte(`{
 		"firstName" : "Prince"
 		}`)
-	err := rs.ValidateBytes(invalidPerson)
-	fmt.Println(err.Error())
+	errs := rs.ValidateBytes(invalidPerson)
+	fmt.Println(errs[0].Error())
 
 	var invalidFriend = []byte(`{
 		"firstName" : "Jay",
@@ -62,11 +62,11 @@ func ExampleBasic() {
 			"firstName" : "Nas"
 			}]
 		}`)
-	err = rs.ValidateBytes(invalidFriend)
-	fmt.Println(err)
+	errs = rs.ValidateBytes(invalidFriend)
+	fmt.Println(errs[0].Error())
 
 	// Output: "lastName" value is required
-	// "friends" property element 0 "lastName" value is required
+	// "friends" property ["lastName" value is required]
 }
 
 func TestDraft3(t *testing.T) {
@@ -318,7 +318,7 @@ func runJSONTests(t *testing.T, testFilepaths []string) {
 			for i, c := range ts.Tests {
 				tests++
 				got := sc.Validate(c.Data)
-				valid := got == nil
+				valid := len(got) == 0
 				if valid != c.Valid {
 					t.Errorf("%s: %s test case %d: %s. error: %s", base, ts.Description, i, c.Description, got)
 				} else {

--- a/schema_test.go
+++ b/schema_test.go
@@ -69,6 +69,32 @@ func ExampleBasic() {
 	// "friends" property ["lastName" value is required]
 }
 
+func TestMust(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok {
+				if err.Error() != "unexpected end of JSON input" {
+					t.Errorf("expected panic error to equal: %s", "unexpected end of JSON input")
+				}
+			} else {
+				t.Errorf("must paniced with a non-error")
+			}
+		} else {
+			t.Errorf("expected invalid call to Must to panic")
+		}
+	}()
+
+	// Valid call to Must shouldn't panic
+	rs := Must(`{}`)
+	if rs == nil {
+		t.Errorf("expected parse of empty schema to return *RootSchema, got nil")
+		return
+	}
+
+	// This should panic, checked in defer above
+	Must(``)
+}
+
 func TestDraft3(t *testing.T) {
 	runJSONTests(t, []string{
 		"testdata/draft3/additionalItems.json",

--- a/validate.go
+++ b/validate.go
@@ -3,13 +3,42 @@ package jsonschema
 // Validator is an interface for anything that can validate.
 // JSON-Schema keywords are all examples of validators
 type Validator interface {
-	// Validate checks decoded JSON data against a given constraint
-	Validate(data interface{}) error
+	// Validate checks decoded JSON data and returns a slice
+	// of validation errors (if any)
+	Validate(data interface{}) []ValError
+}
+
+// ValError represents a single error in an instance of a schema
+// The only absolutely-required property is Message.
+type ValError struct {
+	// PropertyPath is a string path that leads to the
+	// property that produced the error
+	PropertyPath string `json:"propertyPath,omitempty"`
+	// InvalidValue is the value that returned the error
+	InvalidValue interface{} `json:"invalidValue,omitempty"`
+	// RulePath is the path to the rule that errored
+	RulePath string `json:"rulePath,omitempty"`
+	// Message is a human-readable description of the error
+	Message string `json:"message"`
+}
+
+// Error implements the error interface for ValError
+func (v ValError) Error() string {
+	return v.Message
 }
 
 // ValMaker is a function that generates instances of a validator.
 // Calls to ValMaker will be passed directly to json.Marshal, so it should be a pointer
 type ValMaker func() Validator
+
+// RegisterValidator adds a validator to DefaultValidators.
+// Custom Validators should satisfy the validator interface,
+// and be able to get cleanly endcode/decode to JSON
+func RegisterValidator(propName string, maker ValMaker) {
+	// TODO - should this call the function and panic if
+	// the result can't be fed to json.Umarshal?
+	DefaultValidators[propName] = maker
+}
 
 // DefaultValidators is a map of JSON keywords to Validators
 // to draw from when decoding schemas
@@ -59,13 +88,4 @@ var DefaultValidators = map[string]ValMaker{
 	"if":   newIif,
 	"then": newThen,
 	"else": newEls,
-}
-
-// RegisterValidator adds a validator to DefaultValidators.
-// Custom Validators should satisfy the validator interface,
-// and be able to get cleanly endcode/decode to JSON
-func RegisterValidator(propName string, maker ValMaker) {
-	// TODO - should this call the function and panic if
-	// the result can't be fed to json.Umarshal?
-	DefaultValidators[propName] = maker
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -12,10 +12,12 @@ func newIsFoo() Validator {
 	return new(IsFoo)
 }
 
-func (f IsFoo) Validate(data interface{}) error {
+func (f IsFoo) Validate(data interface{}) []ValError {
 	if str, ok := data.(string); ok {
 		if str != "foo" {
-			return fmt.Errorf("'%s' is not foo. It should be foo. plz make '%s' == foo. plz", str, str)
+			return []ValError{
+				{Message: fmt.Sprintf("'%s' is not foo. It should be foo. plz make '%s' == foo. plz", str, str)},
+			}
 		}
 	}
 	return nil
@@ -34,15 +36,15 @@ func ExampleCustomValidator() {
 		panic(err)
 	}
 
-	err := rs.ValidateBytes([]byte(`"bar"`))
-	fmt.Println(err.Error())
+	errs := rs.ValidateBytes([]byte(`"bar"`))
+	fmt.Println(errs[0].Error())
 
 	// Output: 'bar' is not foo. It should be foo. plz make 'bar' == foo. plz
 }
 
 type FooValidator uint8
 
-func (f *FooValidator) Validate(data interface{}) error {
+func (f *FooValidator) Validate(data interface{}) []ValError {
 	return nil
 }
 


### PR DESCRIPTION
This commit introduces a new type: `ValError` and adjusts the signature of `Validator.Validate` to return a slice of `ValError` instead of a single error. This change comes with the expectation that all validators should return the full list of errors that a given validator detects. Error-free passes can return either `nil` or an empty `[]ValError` slice.
This adjustment starts with a basic "just supply the message", but ValError comes with extra fields that we can iterate upon to populate in the future.
Having the full list of errors for a given instance makes this package far more useful, at the expense of forcing implementers to understand a few extra things. Meh. Worth it.

closes #15