### PR TITLE
feat(Validate,ValError): overhaul and upgrade error collection & reporting

### DIFF
--- a/keywords_conditionals.go
+++ b/keywords_conditionals.go
@@ -20,21 +20,24 @@ func NewIf() Validator {
 }
 
 // Validate implements the Validator interface for If
-func (i *If) Validate(data interface{}) []ValError {
-	if err := i.Schema.Validate(data); err == nil {
+func (i *If) Validate(propPath string, data interface{}, errs *[]ValError) {
+	test := &[]ValError{}
+	i.Schema.Validate(propPath, data, test)
+	if len(*test) == 0 {
 		if i.Then != nil {
 			s := Schema(*i.Then)
 			sch := &s
-			return sch.Validate(data)
+			sch.Validate(propPath, data, errs)
+			return
 		}
 	} else {
 		if i.Else != nil {
 			s := Schema(*i.Else)
 			sch := &s
-			return sch.Validate(data)
+			sch.Validate(propPath, data, errs)
+			return
 		}
 	}
-	return nil
 }
 
 // JSONProp implements JSON property name indexing for If
@@ -73,9 +76,7 @@ func NewThen() Validator {
 }
 
 // Validate implements the Validator interface for Then
-func (t *Then) Validate(data interface{}) []ValError {
-	return nil
-}
+func (t *Then) Validate(propPath string, data interface{}, errs *[]ValError) {}
 
 // JSONProp implements JSON property name indexing for Then
 func (t Then) JSONProp(name string) interface{} {
@@ -113,9 +114,7 @@ func NewElse() Validator {
 }
 
 // Validate implements the Validator interface for Else
-func (e *Else) Validate(data interface{}) []ValError {
-	return nil
-}
+func (e *Else) Validate(propPath string, data interface{}, err *[]ValError) {}
 
 // JSONProp implements JSON property name indexing for Else
 func (e Else) JSONProp(name string) interface{} {

--- a/keywords_format.go
+++ b/keywords_format.go
@@ -58,7 +58,7 @@ func NewFormat() Validator {
 }
 
 // Validate validates input against a keyword
-func (f Format) Validate(data interface{}) []ValError {
+func (f Format) Validate(propPath string, data interface{}, errs *[]ValError) {
 	var err error
 	if str, ok := data.(string); ok {
 		switch f {
@@ -100,12 +100,9 @@ func (f Format) Validate(data interface{}) []ValError {
 			err = nil
 		}
 		if err != nil {
-			return []ValError{
-				{Message: err.Error()},
-			}
+			AddError(errs, propPath, data, fmt.Sprintf("invalid %s: %s", f, err.Error()))
 		}
 	}
-	return nil
 }
 
 // A string instance is valid against "date-time" if it is a valid

--- a/keywords_numeric.go
+++ b/keywords_numeric.go
@@ -15,16 +15,13 @@ func NewMultipleOf() Validator {
 }
 
 // Validate implements the Validator interface for MultipleOf
-func (m MultipleOf) Validate(data interface{}) []ValError {
+func (m MultipleOf) Validate(propPath string, data interface{}, errs *[]ValError) {
 	if num, ok := data.(float64); ok {
 		div := num / float64(m)
 		if float64(int(div)) != div {
-			return []ValError{
-				{Message: fmt.Sprintf("%f must be a multiple of %f", num, m)},
-			}
+			AddError(errs, propPath, data, fmt.Sprintf("must be a multiple of %f", m))
 		}
 	}
-	return nil
 }
 
 // Maximum MUST be a number, representing an inclusive upper limit
@@ -38,15 +35,12 @@ func NewMaximum() Validator {
 }
 
 // Validate implements the Validator interface for Maximum
-func (m Maximum) Validate(data interface{}) []ValError {
+func (m Maximum) Validate(propPath string, data interface{}, errs *[]ValError) {
 	if num, ok := data.(float64); ok {
 		if num > float64(m) {
-			return []ValError{
-				{Message: fmt.Sprintf("%f must be less than or equal to %f", num, m)},
-			}
+			AddError(errs, propPath, data, fmt.Sprintf("must be less than or equal to %f", m))
 		}
 	}
-	return nil
 }
 
 // ExclusiveMaximum MUST be number, representing an exclusive upper limit for a numeric instance.
@@ -60,15 +54,12 @@ func NewExclusiveMaximum() Validator {
 }
 
 // Validate implements the Validator interface for ExclusiveMaximum
-func (m ExclusiveMaximum) Validate(data interface{}) []ValError {
+func (m ExclusiveMaximum) Validate(propPath string, data interface{}, errs *[]ValError) {
 	if num, ok := data.(float64); ok {
 		if num >= float64(m) {
-			return []ValError{
-				{Message: fmt.Sprintf("%f must be less than %f", num, m)},
-			}
+			AddError(errs, propPath, data, fmt.Sprintf("must be less than %f", m))
 		}
 	}
-	return nil
 }
 
 // Minimum MUST be a number, representing an inclusive lower limit for a numeric instance.
@@ -81,15 +72,12 @@ func NewMinimum() Validator {
 }
 
 // Validate implements the Validator interface for Minimum
-func (m Minimum) Validate(data interface{}) []ValError {
+func (m Minimum) Validate(propPath string, data interface{}, errs *[]ValError) {
 	if num, ok := data.(float64); ok {
 		if num < float64(m) {
-			return []ValError{
-				{Message: fmt.Sprintf("%f must be greater than or equal to %f", num, m)},
-			}
+			AddError(errs, propPath, data, fmt.Sprintf("must be greater than or equal to %f", m))
 		}
 	}
-	return nil
 }
 
 // ExclusiveMinimum MUST be number, representing an exclusive lower limit for a numeric instance.
@@ -102,13 +90,10 @@ func NewExclusiveMinimum() Validator {
 }
 
 // Validate implements the Validator interface for ExclusiveMinimum
-func (m ExclusiveMinimum) Validate(data interface{}) []ValError {
+func (m ExclusiveMinimum) Validate(propPath string, data interface{}, errs *[]ValError) {
 	if num, ok := data.(float64); ok {
 		if num <= float64(m) {
-			return []ValError{
-				{Message: fmt.Sprintf("%f must be greater than %f", num, m)},
-			}
+			AddError(errs, propPath, data, fmt.Sprintf("must be greater than %f", m))
 		}
 	}
-	return nil
 }

--- a/keywords_strings.go
+++ b/keywords_strings.go
@@ -18,15 +18,12 @@ func NewMaxLength() Validator {
 }
 
 // Validate implements the Validator interface for MaxLength
-func (m MaxLength) Validate(data interface{}) []ValError {
+func (m MaxLength) Validate(propPath string, data interface{}, errs *[]ValError) {
 	if str, ok := data.(string); ok {
 		if utf8.RuneCountInString(str) > int(m) {
-			return []ValError{
-				{Message: fmt.Sprintf("max length of %d characters exceeded: %s", m, str)},
-			}
+			AddError(errs, propPath, data, fmt.Sprintf("max length of %d characters exceeded: %s", m, str))
 		}
 	}
-	return nil
 }
 
 // MinLength MUST be a non-negative integer.
@@ -41,15 +38,12 @@ func NewMinLength() Validator {
 }
 
 // Validate implements the Validator interface for MinLength
-func (m MinLength) Validate(data interface{}) []ValError {
+func (m MinLength) Validate(propPath string, data interface{}, errs *[]ValError) {
 	if str, ok := data.(string); ok {
 		if utf8.RuneCountInString(str) < int(m) {
-			return []ValError{
-				{Message: fmt.Sprintf("min length of %d characters required: %s", m, str)},
-			}
+			AddError(errs, propPath, data, fmt.Sprintf("min length of %d characters required: %s", m, str))
 		}
 	}
-	return nil
 }
 
 // Pattern MUST be a string. This string SHOULD be a valid regular expression,
@@ -64,16 +58,13 @@ func NewPattern() Validator {
 }
 
 // Validate implements the Validator interface for Pattern
-func (p Pattern) Validate(data interface{}) []ValError {
+func (p Pattern) Validate(propPath string, data interface{}, errs *[]ValError) {
 	re := regexp.Regexp(p)
 	if str, ok := data.(string); ok {
 		if !re.Match([]byte(str)) {
-			return []ValError{
-				{Message: fmt.Sprintf("regext pattrn %s mismatch on string: %s", re.String(), str)},
-			}
+			AddError(errs, propPath, data, fmt.Sprintf("regexp pattrn %s mismatch on string: %s", re.String(), str))
 		}
 	}
-	return nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for Pattern

--- a/traversal_test.go
+++ b/traversal_test.go
@@ -21,7 +21,12 @@ func TestSchemaDeref(t *testing.T) {
 		return
 	}
 
-	got := rs.ValidateBytes([]byte(`"a"`))
+	got, err := rs.ValidateBytes([]byte(`"a"`))
+	if err != nil {
+		t.Errorf("error validating bytes: %s", err.Error())
+		return
+	}
+
 	if got == nil {
 		t.Errorf("expected error, got nil")
 		return

--- a/validate.go
+++ b/validate.go
@@ -1,11 +1,23 @@
 package jsonschema
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// MaxValueErrStringLen sets how long a value can be before it's length is truncated
+// when printing error strings
+// a special value of -1 disables output trimming
+var MaxValueErrStringLen = 20
+
 // Validator is an interface for anything that can validate.
 // JSON-Schema keywords are all examples of validators
 type Validator interface {
-	// Validate checks decoded JSON data and returns a slice
-	// of validation errors (if any)
-	Validate(data interface{}) []ValError
+	// Validate checks decoded JSON data and writes
+	// validation errors (if any) to an outparam slice of ValErrors
+	// propPath indicates the position of data in the json tree
+	Validate(propPath string, data interface{}, errs *[]ValError)
 }
 
 // ValError represents a single error in an instance of a schema
@@ -24,11 +36,65 @@ type ValError struct {
 
 // Error implements the error interface for ValError
 func (v ValError) Error() string {
+	// [propPath]: [value] [message]
+	if v.PropertyPath != "" && v.InvalidValue != nil {
+		return fmt.Sprintf("%s: %s %s", v.PropertyPath, InvalidValueString(v.InvalidValue), v.Message)
+	} else if v.PropertyPath != "" {
+		return fmt.Sprintf("%s: %s", v.PropertyPath, v.Message)
+	}
 	return v.Message
 }
 
+// InvalidValueString returns the errored value as a string
+func InvalidValueString(data interface{}) string {
+	bt, err := json.Marshal(data)
+	if err != nil {
+		return ""
+	}
+	bt = bytes.Replace(bt, []byte{'\n', '\r'}, []byte{' '}, -1)
+	if MaxValueErrStringLen != -1 && len(bt) > MaxValueErrStringLen {
+		bt = append(bt[:MaxValueErrStringLen], []byte("...")...)
+	}
+	return string(bt)
+}
+
+// BaseValidator is a foundation for building a validator
+type BaseValidator struct {
+	path string
+}
+
+// SetPath sets base validator's path
+func (b *BaseValidator) SetPath(path string) {
+	b.path = path
+}
+
+// Path gives this validator's path
+func (b BaseValidator) Path() string {
+	return b.path
+}
+
+// AddError is a convenience method for appending a new error to an existing error slice
+func (b BaseValidator) AddError(errs *[]ValError, propPath string, data interface{}, msg string) {
+	*errs = append(*errs, ValError{
+		PropertyPath: propPath,
+		RulePath:     b.Path(),
+		InvalidValue: data,
+		Message:      msg,
+	})
+}
+
+// AddError creates and appends a ValError to errs
+func AddError(errs *[]ValError, propPath string, data interface{}, msg string) {
+	*errs = append(*errs, ValError{
+		PropertyPath: propPath,
+		InvalidValue: data,
+		Message:      msg,
+	})
+}
+
 // ValMaker is a function that generates instances of a validator.
-// Calls to ValMaker will be passed directly to json.Marshal, so it should be a pointer
+// Calls to ValMaker will be passed directly to json.Marshal,
+// so the returned value should be a pointer
 type ValMaker func() Validator
 
 // RegisterValidator adds a validator to DefaultValidators.

--- a/validate_test.go
+++ b/validate_test.go
@@ -12,15 +12,12 @@ func newIsFoo() Validator {
 	return new(IsFoo)
 }
 
-func (f IsFoo) Validate(data interface{}) []ValError {
+func (f IsFoo) Validate(propPath string, data interface{}, errs *[]ValError) {
 	if str, ok := data.(string); ok {
 		if str != "foo" {
-			return []ValError{
-				{Message: fmt.Sprintf("'%s' is not foo. It should be foo. plz make '%s' == foo. plz", str, str)},
-			}
+			AddError(errs, propPath, data, fmt.Sprintf("should be foo. plz make '%s' == foo. plz", str))
 		}
 	}
-	return nil
 }
 
 func ExampleCustomValidator() {
@@ -36,17 +33,18 @@ func ExampleCustomValidator() {
 		panic(err)
 	}
 
-	errs := rs.ValidateBytes([]byte(`"bar"`))
-	fmt.Println(errs[0].Error())
+	errs, err := rs.ValidateBytes([]byte(`"bar"`))
+	if err != nil {
+		panic(err)
+	}
 
-	// Output: 'bar' is not foo. It should be foo. plz make 'bar' == foo. plz
+	fmt.Println(errs[0].Error())
+	// Output: /: "bar" should be foo. plz make 'bar' == foo. plz
 }
 
 type FooValidator uint8
 
-func (f *FooValidator) Validate(data interface{}) []ValError {
-	return nil
-}
+func (f *FooValidator) Validate(propPath string, data interface{}, errs *[]ValError) {}
 
 func TestRegisterValidator(t *testing.T) {
 	newFoo := func() Validator {


### PR DESCRIPTION
To get this package to support returning lots of errors, we've overhauled the message signature for Validation, added a few new methods, and provided convenience methods for creating rich errors that include paths to the errored object, printing a truncated form of the errored value, and set the stage
for providing the path of the validator itself in the error.