### PR TITLE
fix(RootSchema.Unmarshal): permit opaque properties

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -523,8 +523,8 @@ func (s *Schema) UnmarshalJSON(data []byte) error {
 					sch.extraDefinitions = Definitions{}
 				}
 				s := new(Schema)
-				if err := json.Unmarshal(rawmsg, s); err != nil {
-					return fmt.Errorf("error unmarshaling %s from json: %s", prop, err.Error())
+				if err := json.Unmarshal(rawmsg, s); err == nil {
+					sch.extraDefinitions[prop] = s
 				}
 				sch.extraDefinitions[prop] = s
 				continue

--- a/schema_test.go
+++ b/schema_test.go
@@ -562,6 +562,23 @@ func TestValidateBytes(t *testing.T) {
 	}
 }
 
+func TestOpaqueProperties(t *testing.T) {
+	const input = `
+{
+    "$id": "https://www.github.com/schemas/robfig",
+    "properties": {
+        "name": {
+            "type": "string",
+            "opaque": "something"
+        }
+    }
+}`
+	var rs RootSchema
+	if err := rs.UnmarshalJSON([]byte(input)); err != nil {
+		t.Error(err)
+	}
+}
+
 // TODO - finish remoteRef.json tests by setting up a httptest server on localhost:1234
 // that uses an http.Dir to serve up testdata/remotes directory
 // func testServer() {


### PR DESCRIPTION
add a unit test to verify the behavior

fixes #44