### PR TITLE
feat(*): implement json type system

### DIFF
--- a/keywords.go
+++ b/keywords.go
@@ -177,6 +177,8 @@ func (c Const) Validate(propPath string, data Val, errs *[]ValError) {
 	}
 
 	// Normalize the input to match the constant type.
+	// We could do it more efficiently by providing Val.Compare(),
+	// but for now this does the job.
 	var val interface{}
 	b, err := json.Marshal(data.Raw())
 	if err != nil {

--- a/keywords_arrays.go
+++ b/keywords_arrays.go
@@ -40,13 +40,13 @@ func (it Items) Validate(propPath string, data Val, errs *[]ValError) {
 		if it.single {
 			for i, elem := range arr {
 				d, _ := jp.Descendant(strconv.Itoa(i))
-				it.Schemas[0].Validate(d.String(), dataToVal(elem), errs)
+				it.Schemas[0].Validate(d.String(), rawToVal(elem), errs)
 			}
 		} else {
 			for i, vs := range it.Schemas {
 				if i < len(arr) {
 					d, _ := jp.Descendant(strconv.Itoa(i))
-					vs.Validate(d.String(), dataToVal(arr[i]), errs)
+					vs.Validate(d.String(), rawToVal(arr[i]), errs)
 				}
 			}
 		}
@@ -127,7 +127,7 @@ func (a *AdditionalItems) Validate(propPath string, data Val, errs *[]ValError) 
 					continue
 				}
 				d, _ := jp.Descendant(strconv.Itoa(i))
-				a.Schema.Validate(d.String(), dataToVal(elem), errs)
+				a.Schema.Validate(d.String(), rawToVal(elem), errs)
 			}
 		}
 	}
@@ -239,7 +239,7 @@ func (c *Contains) Validate(propPath string, data Val, errs *[]ValError) {
 	if arr, ok := data.(ArrayVal); ok {
 		for _, elem := range arr {
 			test := &[]ValError{}
-			v.Validate(propPath, dataToVal(elem), test)
+			v.Validate(propPath, rawToVal(elem), test)
 			if len(*test) == 0 {
 				return
 			}

--- a/keywords_booleans.go
+++ b/keywords_booleans.go
@@ -15,7 +15,7 @@ func NewAllOf() Validator {
 }
 
 // Validate implements the validator interface for AllOf
-func (a AllOf) Validate(propPath string, data interface{}, errs *[]ValError) {
+func (a AllOf) Validate(propPath string, data Val, errs *[]ValError) {
 	for _, sch := range a {
 		sch.Validate(propPath, data, errs)
 	}
@@ -53,7 +53,7 @@ func NewAnyOf() Validator {
 }
 
 // Validate implements the validator interface for AnyOf
-func (a AnyOf) Validate(propPath string, data interface{}, errs *[]ValError) {
+func (a AnyOf) Validate(propPath string, data Val, errs *[]ValError) {
 	for _, sch := range a {
 		test := &[]ValError{}
 		sch.Validate(propPath, data, test)
@@ -95,7 +95,7 @@ func NewOneOf() Validator {
 }
 
 // Validate implements the validator interface for OneOf
-func (o OneOf) Validate(propPath string, data interface{}, errs *[]ValError) {
+func (o OneOf) Validate(propPath string, data Val, errs *[]ValError) {
 	matched := false
 	for _, sch := range o {
 		test := &[]ValError{}
@@ -145,7 +145,7 @@ func NewNot() Validator {
 }
 
 // Validate implements the validator interface for Not
-func (n *Not) Validate(propPath string, data interface{}, errs *[]ValError) {
+func (n *Not) Validate(propPath string, data Val, errs *[]ValError) {
 	sch := Schema(*n)
 	test := &[]ValError{}
 	sch.Validate(propPath, data, test)

--- a/keywords_conditionals.go
+++ b/keywords_conditionals.go
@@ -20,7 +20,7 @@ func NewIf() Validator {
 }
 
 // Validate implements the Validator interface for If
-func (i *If) Validate(propPath string, data interface{}, errs *[]ValError) {
+func (i *If) Validate(propPath string, data Val, errs *[]ValError) {
 	test := &[]ValError{}
 	i.Schema.Validate(propPath, data, test)
 	if len(*test) == 0 {
@@ -76,7 +76,7 @@ func NewThen() Validator {
 }
 
 // Validate implements the Validator interface for Then
-func (t *Then) Validate(propPath string, data interface{}, errs *[]ValError) {}
+func (t *Then) Validate(propPath string, data Val, errs *[]ValError) {}
 
 // JSONProp implements JSON property name indexing for Then
 func (t Then) JSONProp(name string) interface{} {
@@ -114,7 +114,7 @@ func NewElse() Validator {
 }
 
 // Validate implements the Validator interface for Else
-func (e *Else) Validate(propPath string, data interface{}, err *[]ValError) {}
+func (e *Else) Validate(propPath string, data Val, err *[]ValError) {}
 
 // JSONProp implements JSON property name indexing for Else
 func (e Else) JSONProp(name string) interface{} {

--- a/keywords_conditionals.go
+++ b/keywords_conditionals.go
@@ -1,8 +1,6 @@
 package jsonschema
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // If MUST be a valid JSON Schema.
 // Instances that successfully validate against this keyword's subschema MUST also be valid against the subschema value of the "Then" keyword, if present.

--- a/keywords_format.go
+++ b/keywords_format.go
@@ -1,7 +1,6 @@
 package jsonschema
 
 import (
-	// "encoding/json"
 	"fmt"
 	"net"
 	"net/mail"

--- a/keywords_format.go
+++ b/keywords_format.go
@@ -58,44 +58,44 @@ func NewFormat() Validator {
 }
 
 // Validate validates input against a keyword
-func (f Format) Validate(propPath string, data interface{}, errs *[]ValError) {
+func (f Format) Validate(propPath string, data Val, errs *[]ValError) {
 	var err error
-	if str, ok := data.(string); ok {
+	if str, ok := data.(StringVal); ok {
 		switch f {
 		case "date-time":
-			err = isValidDateTime(str)
+			err = isValidDateTime(string(str))
 		case "date":
-			err = isValidDate(str)
+			err = isValidDate(string(str))
 		case "email":
-			err = isValidEmail(str)
+			err = isValidEmail(string(str))
 		case "hostname":
-			err = isValidHostname(str)
+			err = isValidHostname(string(str))
 		case "idn-email":
-			err = isValidIDNEmail(str)
+			err = isValidIDNEmail(string(str))
 		case "idn-hostname":
-			err = isValidIDNHostname(str)
+			err = isValidIDNHostname(string(str))
 		case "ipv4":
-			err = isValidIPv4(str)
+			err = isValidIPv4(string(str))
 		case "ipv6":
-			err = isValidIPv6(str)
+			err = isValidIPv6(string(str))
 		case "iri-reference":
-			err = isValidIriRef(str)
+			err = isValidIriRef(string(str))
 		case "iri":
-			err = isValidIri(str)
+			err = isValidIri(string(str))
 		case "json-pointer":
-			err = isValidJSONPointer(str)
+			err = isValidJSONPointer(string(str))
 		case "regex":
-			err = isValidRegex(str)
+			err = isValidRegex(string(str))
 		case "relative-json-pointer":
-			err = isValidRelJSONPointer(str)
+			err = isValidRelJSONPointer(string(str))
 		case "time":
-			err = isValidTime(str)
+			err = isValidTime(string(str))
 		case "uri-reference":
-			err = isValidURIRef(str)
+			err = isValidURIRef(string(str))
 		case "uri-template":
-			err = isValidURITemplate(str)
+			err = isValidURITemplate(string(str))
 		case "uri":
-			err = isValidURI(str)
+			err = isValidURI(string(str))
 		default:
 			err = nil
 		}

--- a/keywords_numeric.go
+++ b/keywords_numeric.go
@@ -1,8 +1,6 @@
 package jsonschema
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // MultipleOf MUST be a number, strictly greater than 0.
 // MultipleOf validates that a numeric instance is valid only if division

--- a/keywords_numeric.go
+++ b/keywords_numeric.go
@@ -15,12 +15,19 @@ func NewMultipleOf() Validator {
 }
 
 // Validate implements the Validator interface for MultipleOf
-func (m MultipleOf) Validate(propPath string, data interface{}, errs *[]ValError) {
-	if num, ok := data.(float64); ok {
-		div := num / float64(m)
-		if float64(int(div)) != div {
-			AddError(errs, propPath, data, fmt.Sprintf("must be a multiple of %f", m))
-		}
+func (m MultipleOf) Validate(propPath string, data Val, errs *[]ValError) {
+	var num float64
+	if v, ok := data.(IntVal); ok {
+		num = float64(v.Value())
+	} else if v, ok := data.(NumberVal); ok {
+		num = v.Value()
+	} else {
+		return
+	}
+
+	div := num / float64(m)
+	if float64(int(div)) != div {
+		AddError(errs, propPath, data, fmt.Sprintf("must be a multiple of %f", m))
 	}
 }
 
@@ -35,11 +42,18 @@ func NewMaximum() Validator {
 }
 
 // Validate implements the Validator interface for Maximum
-func (m Maximum) Validate(propPath string, data interface{}, errs *[]ValError) {
-	if num, ok := data.(float64); ok {
-		if num > float64(m) {
-			AddError(errs, propPath, data, fmt.Sprintf("must be less than or equal to %f", m))
-		}
+func (m Maximum) Validate(propPath string, data Val, errs *[]ValError) {
+	var num float64
+	if v, ok := data.(IntVal); ok {
+		num = float64(v.Value())
+	} else if v, ok := data.(NumberVal); ok {
+		num = v.Value()
+	} else {
+		return
+	}
+
+	if num > float64(m) {
+		AddError(errs, propPath, data, fmt.Sprintf("must be less than or equal to %f", m))
 	}
 }
 
@@ -54,11 +68,18 @@ func NewExclusiveMaximum() Validator {
 }
 
 // Validate implements the Validator interface for ExclusiveMaximum
-func (m ExclusiveMaximum) Validate(propPath string, data interface{}, errs *[]ValError) {
-	if num, ok := data.(float64); ok {
-		if num >= float64(m) {
-			AddError(errs, propPath, data, fmt.Sprintf("must be less than %f", m))
-		}
+func (m ExclusiveMaximum) Validate(propPath string, data Val, errs *[]ValError) {
+	var num float64
+	if v, ok := data.(IntVal); ok {
+		num = float64(v.Value())
+	} else if v, ok := data.(NumberVal); ok {
+		num = v.Value()
+	} else {
+		return
+	}
+
+	if num >= float64(m) {
+		AddError(errs, propPath, data, fmt.Sprintf("must be less than %f", m))
 	}
 }
 
@@ -72,11 +93,18 @@ func NewMinimum() Validator {
 }
 
 // Validate implements the Validator interface for Minimum
-func (m Minimum) Validate(propPath string, data interface{}, errs *[]ValError) {
-	if num, ok := data.(float64); ok {
-		if num < float64(m) {
-			AddError(errs, propPath, data, fmt.Sprintf("must be greater than or equal to %f", m))
-		}
+func (m Minimum) Validate(propPath string, data Val, errs *[]ValError) {
+	var num float64
+	if v, ok := data.(IntVal); ok {
+		num = float64(v.Value())
+	} else if v, ok := data.(NumberVal); ok {
+		num = v.Value()
+	} else {
+		return
+	}
+
+	if num < float64(m) {
+		AddError(errs, propPath, data, fmt.Sprintf("must be greater than or equal to %f", m))
 	}
 }
 
@@ -90,10 +118,17 @@ func NewExclusiveMinimum() Validator {
 }
 
 // Validate implements the Validator interface for ExclusiveMinimum
-func (m ExclusiveMinimum) Validate(propPath string, data interface{}, errs *[]ValError) {
-	if num, ok := data.(float64); ok {
-		if num <= float64(m) {
-			AddError(errs, propPath, data, fmt.Sprintf("must be greater than %f", m))
-		}
+func (m ExclusiveMinimum) Validate(propPath string, data Val, errs *[]ValError) {
+	var num float64
+	if v, ok := data.(IntVal); ok {
+		num = float64(v.Value())
+	} else if v, ok := data.(NumberVal); ok {
+		num = v.Value()
+	} else {
+		return
+	}
+
+	if num <= float64(m) {
+		AddError(errs, propPath, data, fmt.Sprintf("must be greater than %f", m))
 	}
 }

--- a/keywords_objects.go
+++ b/keywords_objects.go
@@ -3,9 +3,10 @@ package jsonschema
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/qri-io/jsonpointer"
 	"regexp"
 	"strconv"
+
+	"github.com/qri-io/jsonpointer"
 )
 
 // MaxProperties MUST be a non-negative integer.

--- a/keywords_strings.go
+++ b/keywords_strings.go
@@ -18,9 +18,9 @@ func NewMaxLength() Validator {
 }
 
 // Validate implements the Validator interface for MaxLength
-func (m MaxLength) Validate(propPath string, data interface{}, errs *[]ValError) {
-	if str, ok := data.(string); ok {
-		if utf8.RuneCountInString(str) > int(m) {
+func (m MaxLength) Validate(propPath string, data Val, errs *[]ValError) {
+	if str, ok := data.(StringVal); ok {
+		if utf8.RuneCountInString(string(str)) > int(m) {
 			AddError(errs, propPath, data, fmt.Sprintf("max length of %d characters exceeded: %s", m, str))
 		}
 	}
@@ -38,9 +38,9 @@ func NewMinLength() Validator {
 }
 
 // Validate implements the Validator interface for MinLength
-func (m MinLength) Validate(propPath string, data interface{}, errs *[]ValError) {
-	if str, ok := data.(string); ok {
-		if utf8.RuneCountInString(str) < int(m) {
+func (m MinLength) Validate(propPath string, data Val, errs *[]ValError) {
+	if str, ok := data.(StringVal); ok {
+		if utf8.RuneCountInString(string(str)) < int(m) {
 			AddError(errs, propPath, data, fmt.Sprintf("min length of %d characters required: %s", m, str))
 		}
 	}
@@ -58,9 +58,9 @@ func NewPattern() Validator {
 }
 
 // Validate implements the Validator interface for Pattern
-func (p Pattern) Validate(propPath string, data interface{}, errs *[]ValError) {
+func (p Pattern) Validate(propPath string, data Val, errs *[]ValError) {
 	re := regexp.Regexp(p)
-	if str, ok := data.(string); ok {
+	if str, ok := data.(StringVal); ok {
 		if !re.Match([]byte(str)) {
 			AddError(errs, propPath, data, fmt.Sprintf("regexp pattern %s mismatch on string: %s", re.String(), str))
 		}

--- a/schema.go
+++ b/schema.go
@@ -188,7 +188,7 @@ func (rs *RootSchema) ValidateBytes(data []byte) ([]ValError, error) {
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return errs, fmt.Errorf("error parsing JSON bytes: %s", err.Error())
 	}
-	rs.Validate("/", doc, &errs)
+	rs.Validate("/", dataToVal(doc), &errs)
 	return errs, nil
 }
 
@@ -365,7 +365,7 @@ func (s *Schema) Path() string {
 
 // Validate uses the schema to check an instance, collecting validation
 // errors in a slice
-func (s *Schema) Validate(propPath string, data interface{}, errs *[]ValError) {
+func (s *Schema) Validate(propPath string, data Val, errs *[]ValError) {
 	if s.Ref != "" && s.ref != nil {
 		s.ref.Validate(propPath, data, errs)
 		return

--- a/schema.go
+++ b/schema.go
@@ -188,7 +188,7 @@ func (rs *RootSchema) ValidateBytes(data []byte) ([]ValError, error) {
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return errs, fmt.Errorf("error parsing JSON bytes: %s", err.Error())
 	}
-	rs.Validate("/", dataToVal(doc), &errs)
+	rs.Validate("/", rawToVal(doc), &errs)
 	return errs, nil
 }
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -435,7 +435,7 @@ func runJSONTests(t *testing.T, testFilepaths []string) {
 			for i, c := range ts.Tests {
 				tests++
 				got := []ValError{}
-				sc.Validate("/", c.Data, &got)
+				sc.Validate("/", dataToVal(c.Data), &got)
 				valid := len(got) == 0
 				if valid != c.Valid {
 					t.Errorf("%s: %s test case %d: %s. error: %s", base, ts.Description, i, c.Description, got)
@@ -449,28 +449,28 @@ func runJSONTests(t *testing.T, testFilepaths []string) {
 }
 
 func TestDataType(t *testing.T) {
-	type customObject struct {}
+	type customObject struct{}
 	type customNumber float64
 
 	cases := []struct {
 		data   interface{}
-		expect string
+		expect T
 	}{
-		{nil, "null"},
-		{float64(4), "integer"},
-		{float64(4.5), "number"},
-		{customNumber(4.5), "number"},
-		{"foo", "string"},
-		{[]interface{}{}, "array"},
-		{[0]interface{}{}, "array"},
-		{map[string]interface{}{}, "object"},
-		{struct{}{}, "object"},
-		{customObject{}, "object"},
-		{int8(42), "unknown"},
+		{nil, Null},
+		{float64(4), Integer},
+		{float64(4.5), Number},
+		{customNumber(4.5), Number},
+		{"foo", String},
+		{[]interface{}{}, Array},
+		{[0]interface{}{}, Array},
+		{map[string]interface{}{}, Object},
+		{struct{}{}, Object},
+		{customObject{}, Object},
+		{int8(42), Unknown},
 	}
 
 	for i, c := range cases {
-		got := DataType(c.data)
+		got := dataToT(c.data)
 		if got != c.expect {
 			t.Errorf("case %d result mismatch. expected: '%s', got: '%s'", i, c.expect, got)
 		}

--- a/schema_test.go
+++ b/schema_test.go
@@ -435,7 +435,7 @@ func runJSONTests(t *testing.T, testFilepaths []string) {
 			for i, c := range ts.Tests {
 				tests++
 				got := []ValError{}
-				sc.Validate("/", dataToVal(c.Data), &got)
+				sc.Validate("/", rawToVal(c.Data), &got)
 				valid := len(got) == 0
 				if valid != c.Valid {
 					t.Errorf("%s: %s test case %d: %s. error: %s", base, ts.Description, i, c.Description, got)

--- a/schema_test.go
+++ b/schema_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/sergi/go-diff/diffmatchpatch"

--- a/schema_test.go
+++ b/schema_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/sergi/go-diff/diffmatchpatch"
 	"io/ioutil"
-	// "net/http"
-	// "net/http/httptest"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 func ExampleBasic() {
@@ -472,7 +473,7 @@ func TestDataType(t *testing.T) {
 	for i, c := range cases {
 		got := dataToT(c.data)
 		if got != c.expect {
-			t.Errorf("case %d result mismatch. expected: '%s', got: '%s'", i, c.expect, got)
+			t.Errorf("case %d result mismatch. expected: '%s', got: '%s'", i, mapTStr[c.expect], mapTStr[got])
 		}
 	}
 }

--- a/traversal_test.go
+++ b/traversal_test.go
@@ -100,5 +100,4 @@ func TestReferenceTraversal(t *testing.T) {
 			t.Errorf("case %d: expected %d references, got: %d", i, c.refs, refs)
 		}
 	}
-
 }

--- a/types.go
+++ b/types.go
@@ -1,0 +1,248 @@
+package jsonschema
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type T string
+
+const (
+	Unknown T = "unknown"
+	Null      = "null"
+	Bool      = "boolean"
+	Object    = "object"
+	Array     = "array"
+	Number    = "number"
+	Integer   = "integer"
+	String    = "string"
+)
+
+// dataToT resolves data to a JSON type.
+func dataToT(data interface{}) T {
+	if data == nil {
+		return Null
+	}
+
+	knd := reflect.TypeOf(data).Kind()
+	_ = knd
+
+	switch reflect.TypeOf(data).Kind() {
+	case reflect.Bool:
+		return Bool
+	case reflect.Float64:
+		number := reflect.ValueOf(data).Float()
+		if float64(int(number)) == number {
+			return Integer
+		}
+		return Number
+	case reflect.String:
+		return String
+	case reflect.Array, reflect.Slice:
+		return Array
+	case reflect.Map, reflect.Struct:
+		return Object
+	default:
+		return Unknown
+	}
+}
+
+// Ts is a collection of JSON types.
+type Ts []T
+
+func (ts Ts) String() string {
+	switch len(ts) {
+	case 0:
+		return ""
+	case 1:
+		return string(ts[0])
+	}
+
+	// Calculate string length.
+	n := len(ts) - 1
+	for i := 0; i < len(ts); i++ {
+		n += len(ts[i])
+	}
+
+	var b strings.Builder
+	b.Grow(n)
+	b.WriteString(string(ts[0]))
+	for _, t := range ts[1:] {
+		b.WriteString(",")
+		b.WriteString(string(t))
+	}
+	return b.String()
+}
+
+var mapT = map[T]bool{
+	Null:    true,
+	Bool:    true,
+	Object:  true,
+	Array:   true,
+	Number:  true,
+	Integer: true,
+	String:  true,
+}
+
+type Val interface {
+	Type() T
+	Raw() interface{}
+}
+
+type NullVal struct{}
+
+func (v NullVal) Type() T {
+	return Null
+}
+
+func (v NullVal) Raw() interface{} {
+	return nil
+}
+
+type BoolVal bool
+
+func (v BoolVal) Type() T {
+	return Bool
+}
+
+func (v BoolVal) Raw() interface{} {
+	return bool(v)
+}
+
+type NumberVal float64
+
+func (v NumberVal) Type() T {
+	return Number
+}
+
+func (v NumberVal) Raw() interface{} {
+	return float64(v)
+}
+
+func (v NumberVal) Value() float64 {
+	return float64(v)
+}
+
+type IntVal int64
+
+func (v IntVal) Type() T {
+	return Integer
+}
+
+func (v IntVal) Raw() interface{} {
+	return int64(v)
+}
+
+func (v IntVal) Value() int64 {
+	return int64(v)
+}
+
+type StringVal string
+
+func (v StringVal) Type() T {
+	return String
+}
+
+func (v StringVal) Raw() interface{} {
+	return string(v)
+}
+
+type ObjectVal struct {
+	raw interface{}
+	m   map[string]interface{}
+}
+
+func (v *ObjectVal) Type() T {
+	return Object
+}
+
+func (v *ObjectVal) Raw() interface{} {
+	return v.raw
+}
+
+func (v *ObjectVal) Map() map[string]interface{} {
+	v.ensureM()
+	return v.m
+}
+
+func (v *ObjectVal) ensureM() {
+	if v.raw == nil || v.m != nil {
+		return
+	}
+
+	switch reflect.TypeOf(v.raw).Kind() {
+	case reflect.Map:
+		switch m := v.raw.(type) {
+		case map[string]interface{}:
+			v.m = m
+		case map[interface{}]interface{}:
+			tmp := make(map[string]interface{}, len(m))
+			for k, v := range m {
+				switch str := k.(type) {
+				case string:
+					tmp[str] = v
+				default:
+					return
+				}
+			}
+			v.m = tmp
+		}
+	case reflect.Struct:
+		val := reflect.ValueOf(v.raw)
+		tmp := make(map[string]interface{}, val.NumField())
+		for i := 0; i < val.NumField(); i++ {
+			f := val.Field(i)
+			t := val.Type()
+			tmp[t.Name()] = f.Interface()
+		}
+		v.m = tmp
+	}
+}
+
+type ArrayVal []interface{}
+
+func (v ArrayVal) Type() T {
+	return Array
+}
+
+func (v ArrayVal) Raw() interface{} {
+	return []interface{}(v)
+}
+
+var _ Val = NullVal{}
+var _ Val = BoolVal(false)
+var _ Val = NumberVal(0)
+var _ Val = IntVal(0)
+var _ Val = StringVal("")
+var _ Val = &ObjectVal{}
+var _ Val = ArrayVal{}
+
+func dataToVal(data interface{}) Val {
+	if data == nil {
+		return NullVal{}
+	}
+
+	val := reflect.ValueOf(data)
+
+	switch dataToT(data) {
+	case Bool:
+		return BoolVal(val.Bool())
+	case Number:
+		return NumberVal(val.Float())
+	case Integer:
+		return IntVal(int64(val.Float()))
+	case String:
+		return StringVal(val.String())
+	case Object:
+		return &ObjectVal{raw: data}
+	case Array:
+		arr := make([]interface{}, 0, val.Len())
+		for i := 0; i < val.Len(); i++ {
+			arr = append(arr, val.Index(i).Interface())
+		}
+		return ArrayVal(arr)
+	default:
+		panic(fmt.Sprintf("unable to handle data of type '%v' (%v)", dataToT(data), data))
+	}
+}

--- a/types.go
+++ b/types.go
@@ -1,24 +1,52 @@
 package jsonschema
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 	"unicode"
 )
 
-type T string
+type T int
 
 const (
-	Unknown T = "unknown"
-	Null      = "null"
-	Bool      = "boolean"
-	Object    = "object"
-	Array     = "array"
-	Number    = "number"
-	Integer   = "integer"
-	String    = "string"
+	Unknown T = iota
+	Null
+	Bool
+	Object
+	Array
+	Number
+	Integer
+	String
 )
+
+// MarshalJSON implements the json.Marshaler interface for T
+func (t T) MarshalJSON() ([]byte, error) {
+	return json.Marshal(mapTStr[t])
+}
+
+var mapTStr = [8]string{
+	Unknown: "unknown",
+	Null:    "null",
+	Bool:    "boolean",
+	Object:  "object",
+	Array:   "array",
+	Number:  "number",
+	Integer: "integer",
+	String:  "string",
+}
+
+var mapStrT = map[string]T{
+	"unknown": Unknown,
+	"null":    Null,
+	"boolean": Bool,
+	"object":  Object,
+	"array":   Array,
+	"number":  Number,
+	"integer": Integer,
+	"string":  String,
+}
 
 // dataToT resolves data to a JSON type.
 func dataToT(data interface{}) T {
@@ -57,33 +85,23 @@ func (ts Ts) String() string {
 	case 0:
 		return ""
 	case 1:
-		return string(ts[0])
+		return mapTStr[ts[0]]
 	}
 
 	// Calculate string length.
 	n := len(ts) - 1
 	for i := 0; i < len(ts); i++ {
-		n += len(ts[i])
+		n += len(mapTStr[ts[i]])
 	}
 
 	var b strings.Builder
 	b.Grow(n)
-	b.WriteString(string(ts[0]))
+	b.WriteString(mapTStr[ts[0]])
 	for _, t := range ts[1:] {
 		b.WriteString(",")
-		b.WriteString(string(t))
+		b.WriteString(mapTStr[t])
 	}
 	return b.String()
-}
-
-var mapT = map[T]bool{
-	Null:    true,
-	Bool:    true,
-	Object:  true,
-	Array:   true,
-	Number:  true,
-	Integer: true,
-	String:  true,
 }
 
 type Val interface {

--- a/val_error.go
+++ b/val_error.go
@@ -45,10 +45,10 @@ func InvalidValueString(data interface{}) string {
 }
 
 // AddError creates and appends a ValError to errs
-func AddError(errs *[]ValError, propPath string, data interface{}, msg string) {
+func AddError(errs *[]ValError, propPath string, data Val, msg string) {
 	*errs = append(*errs, ValError{
 		PropertyPath: propPath,
-		InvalidValue: data,
+		InvalidValue: data.Raw(),
 		Message:      msg,
 	})
 }

--- a/validate.go
+++ b/validate.go
@@ -11,7 +11,7 @@ type Validator interface {
 	// Validate checks decoded JSON data and writes
 	// validation errors (if any) to an outparam slice of ValErrors
 	// propPath indicates the position of data in the json tree
-	Validate(propPath string, data interface{}, errs *[]ValError)
+	Validate(propPath string, val Val, errs *[]ValError)
 }
 
 // BaseValidator is a foundation for building a validator
@@ -30,11 +30,11 @@ func (b BaseValidator) Path() string {
 }
 
 // AddError is a convenience method for appending a new error to an existing error slice
-func (b BaseValidator) AddError(errs *[]ValError, propPath string, data interface{}, msg string) {
+func (b BaseValidator) AddError(errs *[]ValError, propPath string, data Val, msg string) {
 	*errs = append(*errs, ValError{
 		PropertyPath: propPath,
 		RulePath:     b.Path(),
-		InvalidValue: data,
+		InvalidValue: data.Raw(),
 		Message:      msg,
 	})
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -12,8 +12,8 @@ func newIsFoo() Validator {
 	return new(IsFoo)
 }
 
-func (f IsFoo) Validate(propPath string, data interface{}, errs *[]ValError) {
-	if str, ok := data.(string); ok {
+func (f IsFoo) Validate(propPath string, data Val, errs *[]ValError) {
+	if str, ok := data.(StringVal); ok {
 		if str != "foo" {
 			AddError(errs, propPath, data, fmt.Sprintf("should be foo. plz make '%s' == foo. plz", str))
 		}
@@ -44,7 +44,7 @@ func ExampleCustomValidator() {
 
 type FooValidator uint8
 
-func (f *FooValidator) Validate(propPath string, data interface{}, errs *[]ValError) {}
+func (f *FooValidator) Validate(propPath string, data Val, errs *[]ValError) {}
 
 func TestRegisterValidator(t *testing.T) {
 	newFoo := func() Validator {


### PR DESCRIPTION
As a continuation to PR #54, I attempted to see what would it take to implement a type system. It turned out not bad. The patch implements json type system, that maps any possible Go type to json type: `null`, `boolean`, `integer`, `number`, `string`, `object`, `array`. It allows validators not to care about specific Go type and their differences. For example, a validator can type assert `object` and read data without needing to differentiate between `map` and `struct`.

The most important part of the patch is a new file `types.go`. The rest is primarily patching existing validators. The new code needs testing, which I'll do if you consider merging.

I benchmarked the current master and this branch using benchmarks from PR #56. It has a significant performance degradation running `type` validator. I haven't checked exactly where most of the time is spent, but is worth to see if we can optimize it.
```
// master
BenchmarkAdditionalItems/sample_size_1-8         	 3000000	       411 ns/op	      52 B/op	       5 allocs/op
BenchmarkAdditionalItems/sample_size_10-8        	 1000000	      2261 ns/op	     232 B/op	      32 allocs/op
BenchmarkAdditionalItems/sample_size_100-8       	  100000	     21225 ns/op	    2248 B/op	     302 allocs/op
BenchmarkAdditionalItems/sample_size_1000-8      	   10000	    241823 ns/op	   27448 B/op	    3902 allocs/op
BenchmarkAdditionalProperties/sample_size_1-8    	 3000000	       571 ns/op	      54 B/op	       5 allocs/op
BenchmarkAdditionalProperties/sample_size_10-8   	  300000	      4278 ns/op	     256 B/op	      32 allocs/op
BenchmarkAdditionalProperties/sample_size_100-8  	   10000	    105712 ns/op	    2428 B/op	     302 allocs/op
BenchmarkAdditionalProperties/sample_size_1000-8 	     200	   8885443 ns/op	   26613 B/op	    3002 allocs/op
BenchmarkConst/sample_size_1-8                   	 1000000	      1141 ns/op	     720 B/op	      13 allocs/op
BenchmarkConst/sample_size_10-8                  	  200000	      6168 ns/op	    2134 B/op	      68 allocs/op
BenchmarkConst/sample_size_100-8                 	   30000	     58875 ns/op	   20591 B/op	     616 allocs/op
BenchmarkConst/sample_size_1000-8                	    2000	    643018 ns/op	  267220 B/op	    6037 allocs/op
BenchmarkContains/sample_size_1-8                	 3000000	       496 ns/op	     208 B/op	       3 allocs/op
BenchmarkContains/sample_size_10-8               	  200000	      9214 ns/op	    3170 B/op	      85 allocs/op
BenchmarkContains/sample_size_100-8              	   20000	     98430 ns/op	   33511 B/op	    1094 allocs/op
BenchmarkContains/sample_size_1000-8             	    2000	   1010793 ns/op	  336124 B/op	   10994 allocs/op
BenchmarkDependencies/sample_size_1-8            	 5000000	       404 ns/op	      38 B/op	       4 allocs/op
BenchmarkDependencies/sample_size_10-8           	 2000000	       602 ns/op	      38 B/op	       4 allocs/op
BenchmarkDependencies/sample_size_100-8          	 1000000	      2200 ns/op	      38 B/op	       4 allocs/op
BenchmarkDependencies/sample_size_1000-8         	   50000	     26662 ns/op	      38 B/op	       4 allocs/op
BenchmarkEnum/sample_size_1-8                    	 3000000	       415 ns/op	     176 B/op	       2 allocs/op
BenchmarkEnum/sample_size_10-8                   	  300000	      5131 ns/op	    1657 B/op	      42 allocs/op
BenchmarkEnum/sample_size_100-8                  	   30000	     46125 ns/op	   15306 B/op	     483 allocs/op
BenchmarkEnum/sample_size_1000-8                 	    3000	    455323 ns/op	  152206 B/op	    4983 allocs/op
BenchmarkMaximum/sample_size_1-8                 	30000000	        46.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaximum/sample_size_10-8                	30000000	        46.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaximum/sample_size_100-8               	30000000	        46.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaximum/sample_size_1000-8              	30000000	        46.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinimum/sample_size_1-8                 	30000000	        46.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinimum/sample_size_10-8                	30000000	        46.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinimum/sample_size_100-8               	30000000	        47.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinimum/sample_size_1000-8              	30000000	        46.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMaximum/sample_size_1-8        	30000000	        46.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMaximum/sample_size_10-8       	30000000	        46.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMaximum/sample_size_100-8      	30000000	        45.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMaximum/sample_size_1000-8     	30000000	        46.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMinimum/sample_size_1-8        	30000000	        45.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMinimum/sample_size_10-8       	30000000	        46.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMinimum/sample_size_100-8      	30000000	        44.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMinimum/sample_size_1000-8     	30000000	        46.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxItems/sample_size_1-8                	30000000	        46.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxItems/sample_size_10-8               	30000000	        47.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxItems/sample_size_100-8              	30000000	        46.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxItems/sample_size_1000-8             	30000000	        46.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinItems/sample_size_1-8                	30000000	        45.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinItems/sample_size_10-8               	30000000	        46.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinItems/sample_size_100-8              	30000000	        45.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinItems/sample_size_1000-8             	30000000	        45.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxLength/sample_size_1-8               	30000000	        47.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxLength/sample_size_10-8              	30000000	        52.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxLength/sample_size_100-8             	20000000	       115 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxLength/sample_size_1000-8            	 2000000	       614 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinLength/sample_size_1-8               	30000000	        48.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinLength/sample_size_10-8              	30000000	        52.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinLength/sample_size_100-8             	20000000	       117 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinLength/sample_size_1000-8            	 2000000	       608 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxProperties/sample_size_1-8           	30000000	        45.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxProperties/sample_size_10-8          	30000000	        46.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxProperties/sample_size_100-8         	30000000	        45.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxProperties/sample_size_1000-8        	30000000	        45.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinProperties/sample_size_1-8           	30000000	        45.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinProperties/sample_size_10-8          	30000000	        45.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinProperties/sample_size_100-8         	30000000	        44.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinProperties/sample_size_1000-8        	30000000	        45.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkMultipleOf/sample_size_1-8              	30000000	        44.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkMultipleOf/sample_size_10-8             	30000000	        46.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkMultipleOf/sample_size_100-8            	30000000	        46.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkMultipleOf/sample_size_1000-8           	30000000	        46.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkPattern/sample_size_1-8                 	 5000000	       245 ns/op	     152 B/op	       2 allocs/op
BenchmarkPattern/sample_size_10-8                	 3000000	       433 ns/op	     160 B/op	       2 allocs/op
BenchmarkPattern/sample_size_100-8               	 1000000	      2184 ns/op	     256 B/op	       2 allocs/op
BenchmarkPattern/sample_size_1000-8              	  100000	     19968 ns/op	    1168 B/op	       2 allocs/op
BenchmarkType/sample_size_1-8                    	 1000000	      2233 ns/op	     150 B/op	      19 allocs/op
BenchmarkType/sample_size_10-8                   	  100000	     23057 ns/op	    1360 B/op	     181 allocs/op
BenchmarkType/sample_size_100-8                  	    5000	    261737 ns/op	   14396 B/op	    1801 allocs/op
BenchmarkType/sample_size_1000-8                 	     500	   2859282 ns/op	  159515 B/op	   18001 allocs/op


// json type system
BenchmarkAdditionalItems/sample_size_1-8         	 3000000	       400 ns/op	      52 B/op	       5 allocs/op
BenchmarkAdditionalItems/sample_size_10-8        	 1000000	      2413 ns/op	     336 B/op	      41 allocs/op
BenchmarkAdditionalItems/sample_size_100-8       	  100000	     22550 ns/op	    3216 B/op	     401 allocs/op
BenchmarkAdditionalItems/sample_size_1000-8      	    5000	    259886 ns/op	   39216 B/op	    4901 allocs/op
BenchmarkAdditionalProperties/sample_size_1-8    	  300000	      4163 ns/op	    4102 B/op	      16 allocs/op
BenchmarkAdditionalProperties/sample_size_10-8   	  100000	     14283 ns/op	    5024 B/op	      88 allocs/op
BenchmarkAdditionalProperties/sample_size_100-8  	   10000	    157243 ns/op	   14403 B/op	     808 allocs/op
BenchmarkAdditionalProperties/sample_size_1000-8 	     100	  10425760 ns/op	  110580 B/op	    8008 allocs/op
BenchmarkConst/sample_size_1-8                   	  500000	      2403 ns/op	    1520 B/op	      28 allocs/op
BenchmarkConst/sample_size_10-8                  	  100000	     12383 ns/op	    4766 B/op	     131 allocs/op
BenchmarkConst/sample_size_100-8                 	   10000	    123338 ns/op	   45159 B/op	    1137 allocs/op
BenchmarkConst/sample_size_1000-8                	    1000	   1390451 ns/op	  580925 B/op	   11082 allocs/op
BenchmarkContains/sample_size_1-8                	 1000000	      1009 ns/op	     392 B/op	       6 allocs/op
BenchmarkContains/sample_size_10-8               	  100000	     14293 ns/op	    5291 B/op	     150 allocs/op
BenchmarkContains/sample_size_100-8              	   10000	    155046 ns/op	   55881 B/op	    1879 allocs/op
BenchmarkContains/sample_size_1000-8             	    1000	   1635063 ns/op	  568191 B/op	   18980 allocs/op
BenchmarkDependencies/sample_size_1-8            	 3000000	       532 ns/op	      86 B/op	       7 allocs/op
BenchmarkDependencies/sample_size_10-8           	 1000000	      1645 ns/op	     374 B/op	      25 allocs/op
BenchmarkDependencies/sample_size_100-8          	  100000	     13244 ns/op	    3254 B/op	     205 allocs/op
BenchmarkDependencies/sample_size_1000-8         	   10000	    119900 ns/op	   32054 B/op	    2005 allocs/op
BenchmarkEnum/sample_size_1-8                    	 2000000	       933 ns/op	     360 B/op	       5 allocs/op
BenchmarkEnum/sample_size_10-8                   	  200000	      7833 ns/op	    2898 B/op	      77 allocs/op
BenchmarkEnum/sample_size_100-8                  	   20000	     69402 ns/op	   26644 B/op	     839 allocs/op
BenchmarkEnum/sample_size_1000-8                 	    2000	    681553 ns/op	  264422 B/op	    8489 allocs/op
BenchmarkMaximum/sample_size_1-8                 	30000000	        40.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaximum/sample_size_10-8                	30000000	        41.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaximum/sample_size_100-8               	30000000	        40.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaximum/sample_size_1000-8              	30000000	        41.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinimum/sample_size_1-8                 	30000000	        41.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinimum/sample_size_10-8                	30000000	        40.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinimum/sample_size_100-8               	30000000	        41.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinimum/sample_size_1000-8              	30000000	        41.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMaximum/sample_size_1-8        	30000000	        40.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMaximum/sample_size_10-8       	30000000	        40.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMaximum/sample_size_100-8      	30000000	        41.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMaximum/sample_size_1000-8     	30000000	        41.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMinimum/sample_size_1-8        	30000000	        40.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMinimum/sample_size_10-8       	30000000	        40.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMinimum/sample_size_100-8      	30000000	        41.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkExclusiveMinimum/sample_size_1000-8     	30000000	        41.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxItems/sample_size_1-8                	30000000	        40.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxItems/sample_size_10-8               	30000000	        40.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxItems/sample_size_100-8              	30000000	        39.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxItems/sample_size_1000-8             	30000000	        40.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinItems/sample_size_1-8                	30000000	        41.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinItems/sample_size_10-8               	30000000	        40.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinItems/sample_size_100-8              	30000000	        40.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinItems/sample_size_1000-8             	30000000	        39.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxLength/sample_size_1-8               	30000000	        43.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxLength/sample_size_10-8              	30000000	        47.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxLength/sample_size_100-8             	20000000	       106 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxLength/sample_size_1000-8            	 3000000	       565 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinLength/sample_size_1-8               	30000000	        42.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinLength/sample_size_10-8              	30000000	        47.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinLength/sample_size_100-8             	20000000	       104 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinLength/sample_size_1000-8            	 3000000	       580 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxProperties/sample_size_1-8           	30000000	        49.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxProperties/sample_size_10-8          	30000000	        48.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxProperties/sample_size_100-8         	30000000	        52.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaxProperties/sample_size_1000-8        	20000000	        51.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinProperties/sample_size_1-8           	30000000	        49.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinProperties/sample_size_10-8          	30000000	        49.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinProperties/sample_size_100-8         	30000000	        48.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkMinProperties/sample_size_1000-8        	30000000	        51.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMultipleOf/sample_size_1-8              	30000000	        43.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMultipleOf/sample_size_10-8             	30000000	        42.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMultipleOf/sample_size_100-8            	30000000	        42.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkMultipleOf/sample_size_1000-8           	30000000	        42.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkPattern/sample_size_1-8                 	10000000	       229 ns/op	     152 B/op	       2 allocs/op
BenchmarkPattern/sample_size_10-8                	 3000000	       390 ns/op	     160 B/op	       2 allocs/op
BenchmarkPattern/sample_size_100-8               	 1000000	      1840 ns/op	     256 B/op	       2 allocs/op
BenchmarkPattern/sample_size_1000-8              	  100000	     19207 ns/op	    1168 B/op	       2 allocs/op
BenchmarkType/sample_size_1-8                    	  200000	      6459 ns/op	    2460 B/op	      40 allocs/op
BenchmarkType/sample_size_10-8                   	   30000	     43821 ns/op	    6612 B/op	     364 allocs/op
BenchmarkType/sample_size_100-8                  	    3000	    408302 ns/op	   48407 B/op	    3604 allocs/op
BenchmarkType/sample_size_1000-8                 	     300	   4176650 ns/op	  489146 B/op	   36004 allocs/op
```