### PR TITLE
Return correct error message when `minLength` validation failed

### DIFF
--- a/keywords_string.go
+++ b/keywords_string.go
@@ -57,7 +57,7 @@ func (m MinLength) ValidateKeyword(ctx context.Context, currentState *Validation
 	schemaDebug("[MinLength] Validating")
 	if str, ok := data.(string); ok {
 		if utf8.RuneCountInString(str) < int(m) {
-			currentState.AddError(data, fmt.Sprintf("max length of %d characters exceeded: %s", m, str))
+			currentState.AddError(data, fmt.Sprintf("min length of %d characters required: %s", m, str))
 		}
 	}
 }


### PR DESCRIPTION
Suppose, Schema contains one of the properties contains `minLength` like 
```
{
    "type": "object",
    "properties": {
        "id": {
            "type": "string",
            "maxLength": 8,
            "minLength": 8
        }
    }
}
```
and attempted to validate JSON like 

```
{
"id":"test"
}
```

Currently, Validation raises message like `max length of 8 characters exceeded: test` and it is invalid error message. This pull request contains error message correction.