### PR TITLE
Fix email validation

### DIFF
--- a/keywords_optional.go
+++ b/keywords_optional.go
@@ -123,11 +123,12 @@ func isValidDate(date string) error {
 // representation as defined by RFC 5322, section 3.4.1 [RFC5322].
 // https://tools.ietf.org/html/rfc5322#section-3.4.1
 func isValidEmail(email string) error {
-	// if !emailPattern.MatchString(email) {
-	// 	return fmt.Errorf("invalid email Format")
-	// }
-	if _, err := mail.ParseAddress(email); err != nil {
+	res, err := mail.ParseAddress(email)
+	if err != nil {
 		return fmt.Errorf("email address incorrectly Formatted: %s", err.Error())
+	}
+	if res.Address != email {
+		return fmt.Errorf("email address incorrectly Formatted: %s", email)
 	}
 	return nil
 }

--- a/testdata/draft2019-09/optional/format/email.json
+++ b/testdata/draft2019-09/optional/format/email.json
@@ -12,6 +12,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": " joe.bloggs@example.com",
+                "valid": false
             }
         ]
     }

--- a/testdata/draft3/optional/format.json
+++ b/testdata/draft3/optional/format.json
@@ -112,6 +112,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": " joe.bloggs@example.com",
+                "valid": false
             }
         ]
     },

--- a/testdata/draft4/optional/format.json
+++ b/testdata/draft4/optional/format.json
@@ -164,6 +164,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": " joe.bloggs@example.com",
+                "valid": false
             }
         ]
     },

--- a/testdata/draft6/optional/format.json
+++ b/testdata/draft6/optional/format.json
@@ -236,6 +236,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": " joe.bloggs@example.com",
+                "valid": false
             }
         ]
     },

--- a/testdata/draft7/optional/format/email.json
+++ b/testdata/draft7/optional/format/email.json
@@ -12,6 +12,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": " joe.bloggs@example.com",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
mail.ParseAddress return an reformated email if the format is not really an email (with a space after of before for example).
A check was added to compare the input and the output from mail.ParseAddress.