### PR TITLE
refactor(resolve): change FetchSchema to support custom schema loaders

### DIFF
--- a/schema_loader.go
+++ b/schema_loader.go
@@ -1,0 +1,103 @@
+package jsonschema
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+var lr *LoaderRegistry
+
+type LoaderRegistry struct {
+	loaderLookup map[string]SchemaLoaderFunc
+}
+
+type SchemaLoaderFunc func(ctx context.Context, uri *url.URL, schema *Schema) error
+
+func NewLoaderRegistry() *LoaderRegistry {
+	r := &LoaderRegistry{
+		loaderLookup: map[string]SchemaLoaderFunc{},
+	}
+
+	r.Register("http", HTTPSchemaLoader)
+	r.Register("https", HTTPSchemaLoader)
+	r.Register("file", FileSchemaLoader)
+
+	return r
+}
+
+// Register a new schema loader for a specific URI Scheme
+func (r *LoaderRegistry) Register(scheme string, loader SchemaLoaderFunc) {
+	r.loaderLookup[scheme] = loader
+}
+
+// Get the schema loader func for a specific URI Scheme
+func (r *LoaderRegistry) Get(scheme string) (SchemaLoaderFunc, bool) {
+	l, exists := r.loaderLookup[scheme]
+	return l, exists
+}
+
+// GetGlobalLoaderRegistry provides an accessor to a globally available (schema) loader registry
+func GetGlobalLoaderRegistry() *LoaderRegistry {
+	if lr == nil {
+		lr = NewLoaderRegistry()
+	}
+	return lr
+}
+
+// FetchSchema downloads and loads a schema from a remote location
+func FetchSchema(ctx context.Context, uri string, schema *Schema) error {
+	schemaDebug(fmt.Sprintf("[FetchSchema] Fetching: %s", uri))
+	u, err := url.Parse(uri)
+	if err != nil {
+		return err
+	}
+
+	registry := GetGlobalLoaderRegistry()
+
+	loader, exists := registry.Get(u.Scheme)
+
+	if !exists {
+		return fmt.Errorf("URI scheme %s is not supported for uri: %s", u.Scheme, uri)
+	}
+
+	return loader(ctx, u, schema)
+}
+
+// HTTPSchemaLoader loads a schema from a http or https URI
+func HTTPSchemaLoader(ctx context.Context, uri *url.URL, schema *Schema) error {
+	var req *http.Request
+	if ctx != nil {
+		req, _ = http.NewRequestWithContext(ctx, "GET", uri.String(), nil)
+	} else {
+		req, _ = http.NewRequest("GET", uri.String(), nil)
+	}
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	if schema == nil {
+		schema = &Schema{}
+	}
+	return json.Unmarshal(body, schema)
+}
+
+// FileSchemaLoader loads a schema from a file URI
+func FileSchemaLoader(ctx context.Context, uri *url.URL, schema *Schema) error {
+	body, err := ioutil.ReadFile(uri.Path)
+	if err != nil {
+		return err
+	}
+	if schema == nil {
+		schema = &Schema{}
+	}
+	return json.Unmarshal(body, schema)
+}

--- a/schema_loader.go
+++ b/schema_loader.go
@@ -11,12 +11,15 @@ import (
 
 var lr *LoaderRegistry
 
+// LoaderRegistry maintains a lookup table between uri schemes and associated loader
 type LoaderRegistry struct {
 	loaderLookup map[string]SchemaLoaderFunc
 }
 
+// SchemaLoaderFunc is a function that loads a schema for a specific URI Scheme
 type SchemaLoaderFunc func(ctx context.Context, uri *url.URL, schema *Schema) error
 
+// NewLoaderRegistry allocates a new schema loader registry
 func NewLoaderRegistry() *LoaderRegistry {
 	r := &LoaderRegistry{
 		loaderLookup: map[string]SchemaLoaderFunc{},

--- a/schema_loader.go
+++ b/schema_loader.go
@@ -40,8 +40,8 @@ func (r *LoaderRegistry) Get(scheme string) (SchemaLoaderFunc, bool) {
 	return l, exists
 }
 
-// GetGlobalLoaderRegistry provides an accessor to a globally available (schema) loader registry
-func GetGlobalLoaderRegistry() *LoaderRegistry {
+// GetSchemaLoaderRegistry provides an accessor to a globally available (schema) loader registry
+func GetSchemaLoaderRegistry() *LoaderRegistry {
 	if lr == nil {
 		lr = NewLoaderRegistry()
 	}
@@ -56,7 +56,7 @@ func FetchSchema(ctx context.Context, uri string, schema *Schema) error {
 		return err
 	}
 
-	registry := GetGlobalLoaderRegistry()
+	registry := GetSchemaLoaderRegistry()
 
 	loader, exists := registry.Get(u.Scheme)
 

--- a/schema_loader_test.go
+++ b/schema_loader_test.go
@@ -82,7 +82,7 @@ func TestFetchSchema(t *testing.T) {
 
 func TestCustomSchemaLoader(t *testing.T) {
 
-	lr := jsonschema.GetGlobalLoaderRegistry()
+	lr := jsonschema.GetSchemaLoaderRegistry()
 	lr.Register("special", func(ctx context.Context, uri *url.URL, schema *jsonschema.Schema) error {
 
 		path := uri.Host + uri.Path

--- a/schema_loader_test.go
+++ b/schema_loader_test.go
@@ -1,0 +1,116 @@
+package jsonschema_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/qri-io/jsonschema"
+)
+
+func createTestServer() *httptest.Server {
+	validSchema := `{
+		"type": "string"
+	}`
+	invalidSchema := "invalid_schema"
+	return httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/valid_schema.json":
+				fmt.Fprintln(w, validSchema)
+			default:
+				fmt.Fprintln(w, invalidSchema)
+			}
+		}))
+}
+
+func TestFetchSchema(t *testing.T) {
+
+	ts := createTestServer()
+	defer ts.Close()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("failed to get working dir: %q", err)
+	}
+
+	cases := []struct {
+		uri          string
+		expectsError bool
+		message      string
+	}{
+		{fmt.Sprintf("%s/valid_schema.json", ts.URL), false, ""},
+		{fmt.Sprintf("%s/invalid_schema.json", ts.URL), true, "invalid character"},
+		{fmt.Sprintf("file://%s/testdata/draft-07_schema.json", wd), false, ""},
+		{fmt.Sprintf("file://%s/testdata/missing_file.json", wd), true, "no such file or directory"},
+		{"unknownscheme://resource.json#definitions/property", true, "unknownscheme is not supported for uri"},
+	}
+
+	for i, c := range cases {
+		rs := &jsonschema.Schema{}
+		err := jsonschema.FetchSchema(context.Background(), c.uri, rs)
+
+		if !c.expectsError && err == nil {
+			continue
+		}
+
+		if c.expectsError {
+			if err == nil {
+				t.Errorf("case %d expected an error", i)
+				continue
+			}
+
+			if !strings.Contains(err.Error(), c.message) {
+				t.Errorf("case %d expected error to include %q actual: %q", i, c.message, err.Error())
+				continue
+			}
+
+		} else if err != nil {
+			t.Errorf("case %d unexpected error: %s", i, err)
+			continue
+		}
+
+	}
+
+}
+
+func TestCustomSchemaLoader(t *testing.T) {
+
+	lr := jsonschema.GetGlobalLoaderRegistry()
+	lr.Register("special", func(ctx context.Context, uri *url.URL, schema *jsonschema.Schema) error {
+
+		path := uri.Host + uri.Path
+		body := fmt.Sprintf(`{ "type": "string", "description": "example description for '%s'"}`, path)
+		if schema == nil {
+			schema = &jsonschema.Schema{}
+		}
+		return json.Unmarshal([]byte(body), schema)
+
+	})
+
+	resourceURI := "special://schema_name"
+	rs := &jsonschema.Schema{}
+	err := jsonschema.FetchSchema(context.Background(), resourceURI, rs)
+
+	if err != nil {
+		t.Errorf("failed to load schema: %s", err)
+		return
+	}
+
+	if rs.TopLevelType() != "string" {
+		t.Errorf("expected schema top level type to be %q, actual: %q", "string", rs.TopLevelType())
+	}
+
+	expectedDesc := "example description for 'schema_name'"
+	actualDesc := string(*rs.JSONProp("description").(*jsonschema.Description))
+	if actualDesc != expectedDesc {
+		t.Errorf("expected 'description' to be %q, actual: %v", expectedDesc, actualDesc)
+	}
+
+}

--- a/util.go
+++ b/util.go
@@ -1,11 +1,7 @@
 package jsonschema
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -50,46 +46,4 @@ func IsLocalSchemaID(id string) bool {
 		return false
 	}
 	return id != "#" && !strings.HasPrefix(id, "#/") && strings.Contains(id, "#")
-}
-
-// FetchSchema downloads and loads a schema from a remote location
-func FetchSchema(ctx context.Context, uri string, schema *Schema) error {
-	schemaDebug(fmt.Sprintf("[FetchSchema] Fetching: %s", uri))
-	u, err := url.Parse(uri)
-	if err != nil {
-		return err
-	}
-	// TODO(arqu): support other schemas like file or ipfs
-	if u.Scheme == "http" || u.Scheme == "https" {
-		var req *http.Request
-		if ctx != nil {
-			req, _ = http.NewRequestWithContext(ctx, "GET", u.String(), nil)
-		} else {
-			req, _ = http.NewRequest("GET", u.String(), nil)
-		}
-		client := &http.Client{}
-		res, err := client.Do(req)
-		if err != nil {
-			return err
-		}
-		body, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-		if schema == nil {
-			schema = &Schema{}
-		}
-		return json.Unmarshal(body, schema)
-	}
-	if u.Scheme == "file" {
-		body, err := ioutil.ReadFile(u.Path)
-		if err != nil {
-			return err
-		}
-		if schema == nil {
-			schema = &Schema{}
-		}
-		return json.Unmarshal(body, schema)
-	}
-	return fmt.Errorf("URI scheme %s is not supported for uri: %s", u.Scheme, uri)
 }


### PR DESCRIPTION
Added support for custom schema loaders based on the URI scheme

Some things to highlight:

- Created a global loader registry similarly to the `schemaRegistry` and `keywordRegistry`
- Converted `http(s)` and `file` to loader functions and they included by default on the global registry.
