### PR TITLE
Include child in failed validation path when disallowed additional properties are found

### DIFF
--- a/keywords_object.go
+++ b/keywords_object.go
@@ -325,13 +325,15 @@ func (ap *AdditionalProperties) ValidateKeyword(ctx context.Context, currentStat
 			if currentState.IsLocallyEvaluatedKey(key) {
 				continue
 			}
-			if ap.schemaType == schemaTypeFalse {
-				currentState.AddError(data, "additional properties are not allowed")
-				return
-			}
+
 			currentState.SetEvaluatedKey(key)
 			subState.ClearState()
 			subState.DescendInstanceFromState(currentState, key)
+
+			if ap.schemaType == schemaTypeFalse {
+				subState.AddError(data, "additional properties are not allowed")
+				return
+			}
 
 			(*Schema)(ap).ValidateKeyword(ctx, subState, obj[key])
 			currentState.UpdateEvaluatedPropsAndItems(subState)

--- a/schema_test.go
+++ b/schema_test.go
@@ -666,6 +666,18 @@ func TestValidateBytes(t *testing.T) {
 				`/1: false type should be string, got boolean`,
 				`/2: type should be string, got null`,
 			}},
+		{`{
+		"type": "object",
+		"properties" : {
+		},
+		"additionalProperties" : false
+	}`,
+			`{
+	"port": 80
+}`,
+			[]string{
+				`/port: {"port":80} additional properties are not allowed`,
+			}},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
When it fails validating a child, the error path should be for the child key, not the root.

@Arqu had said that perhaps this fix should target the 2020 spec, but I wasn't sure where that change should be made? Happy to move the fix elsewhere if someone can point me in the right direction.

Fixes #91