### PR TITLE
feat(validation): Add a shared storage between all substates of a ValidateState

### DIFF
--- a/validation_state.go
+++ b/validation_state.go
@@ -26,6 +26,9 @@ type ValidationState struct {
 	Misc                        map[string]interface{}
 
 	Errs *[]KeyError
+
+	// ExtraData is a shared storage between all substates of a ValidationState
+	ExtraData *map[string]interface{}
 }
 
 // NewValidationState creates a new ValidationState with the provided location pointers and data instance
@@ -45,6 +48,7 @@ func NewValidationState(s *Schema) *ValidationState {
 		LocalEvaluatedPropertyNames: &map[string]bool{},
 		Misc:                        map[string]interface{}{},
 		Errs:                        &[]KeyError{},
+		ExtraData:                   &map[string]interface{}{},
 	}
 }
 
@@ -65,7 +69,19 @@ func (vs *ValidationState) NewSubState() *ValidationState {
 		LocalEvaluatedPropertyNames: vs.LocalEvaluatedPropertyNames,
 		Misc:                        map[string]interface{}{},
 		Errs:                        vs.Errs,
+		ExtraData:                   vs.ExtraData,
 	}
+}
+
+// GetExtraData retrieves a key from the shared validation store(ExtraData).
+func (vs *ValidationState) GetExtraData(key string) (interface{}, bool) {
+	data, exists := (*vs.ExtraData)[key]
+	return data, exists
+}
+
+// SetExtraData stores data into the shared validation store(ExtraData)
+func (vs *ValidationState) SetExtraData(key string, value interface{}) {
+	(*vs.ExtraData)[key] = value
 }
 
 // ClearState resets a schema to it's core elements


### PR DESCRIPTION
This new field is similar to the `Misc` field from a `ValidationState` but is shared between all a ValidationState and all its child SubStates.

In the project I'm using this library I have a few custom keywords and I need to be able to identify which are the datapaths that are associated with such keywords.

The easiest way I could think of solving this problem was by having this shared storage at the `ValidationState` level. 
This way, in my custom keyword `ValidateKeyword` method, I could save the necessary info and have it available as a result of the validation.