### PR TITLE
fix: data type check unsupported Ptr and Interface

### DIFF
--- a/keywords_standard.go
+++ b/keywords_standard.go
@@ -161,6 +161,8 @@ func DataType(data interface{}) string {
 		return "array"
 	case reflect.Map, reflect.Struct:
 		return "object"
+	case reflect.Ptr, reflect.Interface:
+		return "null"
 	default:
 		return "unknown"
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -567,11 +567,18 @@ func TestDataType(t *testing.T) {
 	type customObject struct{}
 	type customNumber float64
 
+	var nilPoint *struct{}
+	var nilInterface interface{}
+	var nilInterfaceReader interface{ Read() }
+
 	cases := []struct {
 		data   interface{}
 		expect string
 	}{
 		{nil, "null"},
+		{nilPoint, "null"},
+		{nilInterface, "null"},
+		{nilInterfaceReader, "null"},
 		{float64(4), "integer"},
 		{float64(4.0), "integer"},
 		{float64(4.5), "number"},


### PR DESCRIPTION
We currently have some scenarios where we construct map[string]interface{} directly and then call jsonschema.Validate , which avoids a json.Marshal operation, but I found that the DataType detection, when encountering a Pointer or Interface of nil, has Here it returns "unknown", when I would expect it to return "null".