### PR TITLE
fix(MarshalJSON): custom JSON marshalling for AdditionalProperties schema type

### DIFF
--- a/keywords_object.go
+++ b/keywords_object.go
@@ -351,6 +351,11 @@ func (ap *AdditionalProperties) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaler interface for AdditionalProperties
+func (ap *AdditionalProperties) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Schema(*ap))
+}
+
 // PropertyNames defines the propertyNames JSON Schema keyword
 type PropertyNames Schema
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -88,6 +89,35 @@ func ExampleBasic() {
 
 	// Output: /: {"firstName":"Prince... "lastName" value is required
 	// /friends/0: {"firstName":"Nas"} "lastName" value is required
+}
+
+func TestRoundTripMarshallingForAdditionalProperties(t *testing.T) {
+	schemaObject := []byte(`{
+    "title": "Car",
+    "type": "object",
+    "properties": {
+        "color": {
+            "type": "string"
+        }
+    },
+    "required": ["color"],
+    "additionalProperties": false
+}`)
+	rs := &Schema{}
+	if err := json.Unmarshal(schemaObject, rs); err != nil {
+		t.Fatalf("failed to unmarshal test data: %s", err.Error())
+	}
+	bytes, err := json.Marshal(rs)
+	if err != nil {
+		t.Fatalf("failed to unmarshal test data: %s", err.Error())
+	}
+	var rs1 Schema
+	if err := json.Unmarshal(bytes, &rs1); err != nil {
+		t.Fatalf("failed to unmarshal test data: %s", err.Error())
+	}
+	if !reflect.DeepEqual(rs, &rs1) {
+		t.Fatalf("not equal")
+	}
 }
 
 func TestTopLevelType(t *testing.T) {


### PR DESCRIPTION
The AdditionalProperties schema type is defined as a Schema subtype, however this does not imply that the `MarshalJSON` func implemented on `Schema` is used for marshalling. This PR overrides `MarshalJSON` for `AdditionalProperties` by redirecting it to the implementation in `Schema`